### PR TITLE
Enhance `attributeChanged` Decorator to Support Setters in Custom Elements

### DIFF
--- a/src/attributeChanged/attributeChanged.js
+++ b/src/attributeChanged/attributeChanged.js
@@ -26,23 +26,31 @@ import { attributeChangedCallback, observedAttributes } from "../interfaces";
  *
  * customElements.define('my-element', MyElement);
  */
-const attributeChanged = (attributeName) => (target, propertyKey) => {
-  // Atualiza a lista de atributos observados do Custom Element.
-  const observedAttrs = target.constructor[observedAttributes] ?? [];
+const attributeChanged =
+  (attributeName) => (target, propertyKey, propertyDescriptor) => {
+    // Atualiza a lista de atributos observados do Custom Element.
+    const observedAttrs = target.constructor[observedAttributes] ?? [];
 
-  Object.assign(target.constructor, {
-    [observedAttributes]: [...observedAttrs, attributeName],
-  });
-
-  // Configura o interceptor para o método `attributeChangedCallback`.
-  intercept(attributeChangedCallback)
-    .in(target)
-    .then(function (name, oldValue, newValue) {
-      if (name === attributeName && oldValue !== newValue) {
-        // Executa o método decorado com os novos e antigos valores do atributo.
-        this[propertyKey](newValue, oldValue);
-      }
+    Object.assign(target.constructor, {
+      [observedAttributes]: [...observedAttrs, attributeName],
     });
-};
+
+    // Configura o interceptor para o método `attributeChangedCallback`.
+    intercept(attributeChangedCallback)
+      .in(target)
+      .then(function (name, oldValue, newValue) {
+        if (name === attributeName && oldValue !== newValue) {
+          // Se o método for um setter, atualiza o valor do atributo.
+          if (propertyDescriptor.set) {
+            this[propertyKey] = newValue;
+          }
+
+          // Se o método for uma função, executa o método decorado com os novos e antigos valores do atributo.
+          if (propertyDescriptor.value) {
+            this[propertyKey](newValue, oldValue);
+          }
+        }
+      });
+  };
 
 export default attributeChanged;


### PR DESCRIPTION
### Descrição

Este Pull Request aprimora o decorator `attributeChanged` para permitir a utilização de setters ao lidar com mudanças de atributos em Custom Elements. A nova lógica verifica se o método decorado é um setter e, se for, atualiza o valor do atributo diretamente através do setter, além de manter a funcionalidade existente para métodos normais.

### Modificações

- **Decorator `attributeChanged`:** Agora suporta a atualização de atributos por meio de setters em Custom Elements.
  - **Lógica Adicionada:**
    - Verifica se o método decorado é um setter usando `propertyDescriptor.set`.
    - Atualiza o valor do atributo diretamente pelo setter, caso seja aplicável.
    - Mantém a execução do método decorado como função se `propertyDescriptor.value` estiver presente.

### Implementação

```javascript
import intercept from "../intercept";
import { attributeChangedCallback, observedAttributes } from "../interfaces";

const attributeChanged = (attributeName) => (target, propertyKey) => {
  const observedAttrs = target.constructor[observedAttributes] ?? [];

  Object.assign(target.constructor, {
    [observedAttributes]: [...observedAttrs, attributeName],
  });

  const propertyDescriptor = Object.getOwnPropertyDescriptor(target, propertyKey);

  intercept(attributeChangedCallback)
    .in(target)
    .then(function (name, oldValue, newValue) {
      if (name === attributeName && oldValue !== newValue) {
        // Se o método for um setter, atualiza o valor do atributo.
        if (propertyDescriptor.set) {
          this[propertyKey] = newValue;
        }

        // Se o método for uma função, executa o método decorado com os novos e antigos valores do atributo.
        if (propertyDescriptor.value) {
          this[propertyKey](newValue, oldValue);
        }
      }
    });
};

export default attributeChanged;
```

### Exemplo de Uso

```javascript
import { attributeChanged } from '@bake-js/-o-id';

class MyElement extends HTMLElement {
  @attributeChanged('value')
  set value(newValue) {
    this._value = newValue;
    console.log(`Valor do atributo 'value' atualizado para: ${newValue}`);
  }

  get value() {
    return this._value;
  }

  handleAttributeChange(newValue, oldValue) {
    console.log(`Atributo 'value' alterado de ${oldValue} para ${newValue}`);
  }
}

customElements.define('my-element', MyElement);
```

### Como Testar

1. Faça o checkout para este branch.
2. Execute `npm install` para instalar as dependências.
3. Teste a implementação criando um Custom Element com um atributo que utilize um setter para verificar se o valor é atualizado corretamente.
4. Execute `npm test` para garantir que todas as funcionalidades estão funcionando conforme o esperado.

### Considerações

- **Compatibilidade:** Esta mudança mantém a compatibilidade com o comportamento existente do `attributeChanged`, garantindo que tanto métodos normais quanto setters funcionem conforme o esperado.
- **Documentação:** Atualizei a documentação para refletir a nova funcionalidade, garantindo que os desenvolvedores entendam como usar setters com o decorator `attributeChanged`.

### Notas Finais

Esta atualização torna o decorator `attributeChanged` mais flexível e capaz de lidar com diferentes cenários ao trabalhar com Custom Elements, melhorando a experiência de desenvolvimento e a consistência do código.